### PR TITLE
chore: bump MSRV from 1.85 to 1.88

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,10 +51,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup Rust 1.85.0 toolchain
+      - name: Setup Rust 1.88.0 toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85.0
+          toolchain: 1.88.0
           cache-key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build with MSRV

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Recallable is a Rust library implementing the Memento design pattern via procedural macros. It generates companion "memento" structs and state restoration logic at compile time. Two-crate workspace: `recallable` (traits) and `recallable-macro` (proc macros).
 
-MSRV: Rust 1.85 (edition 2024). `no_std` compatible.
+MSRV: Rust 1.88 (edition 2024). `no_std` compatible.
 
 ## Commands
 
@@ -21,7 +21,7 @@ cargo fmt -- --check                                  # Format check
 cargo clippy --workspace --all-targets --all-features # Lint
 ```
 
-CI runs the test matrix on stable and validates the MSRV on Rust 1.85.0. Coverage thresholds: 100% function, 90% line, 90% region.
+CI runs the test matrix on stable and validates the MSRV on Rust 1.88.0. Coverage thresholds: 100% function, 90% line, 90% region.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing to Recallable! We welcome contributi
 
 ### Prerequisites
 
-- Rust 1.85 or newer (latest stable recommended for day-to-day development)
+- Rust 1.88 or newer (latest stable recommended for day-to-day development)
 - Cargo
 
 ### Building the Project

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.package]
 version = "0.1.0"
-rust-version = "1.85"
+rust-version = "1.88"
 edition = "2024"
 repository = "https://github.com/ShapelessCat/recallable"
 homepage = "https://github.com/ShapelessCat/recallable"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![CI](https://github.com/ShapelessCat/recallable/actions/workflows/ci.yaml/badge.svg)](https://github.com/ShapelessCat/recallable/actions/workflows/ci.yaml)
 [![Crates.io](https://img.shields.io/crates/v/recallable.svg)](https://crates.io/crates/recallable)
 [![Documentation](https://docs.rs/recallable/badge.svg)](https://docs.rs/recallable)
-[![recallable MSRV](https://img.shields.io/crates/msrv/recallable.svg?label=recallable%20msrv&color=lightgray)](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html)
-[![recallable-macro MSRV](https://img.shields.io/crates/msrv/recallable-macro.svg?label=recallable-macro%20msrv&color=lightgray)](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html)
+[![recallable MSRV](https://img.shields.io/crates/msrv/recallable.svg?label=recallable%20msrv&color=lightgray)](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0.html)
+[![recallable-macro MSRV](https://img.shields.io/crates/msrv/recallable-macro.svg?label=recallable-macro%20msrv&color=lightgray)](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0.html)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
@@ -65,7 +65,7 @@ The provided procedural macros handle the heavy lifting; they generate companion
 
 ## Installation
 
-**MSRV:** Rust 1.85 (edition 2024). CI validates both the current stable toolchain and Rust 1.85.0.
+**MSRV:** Rust 1.88 (edition 2024). CI validates both the current stable toolchain and Rust 1.88.0.
 
 Add this to your `Cargo.toml`:
 

--- a/recallable-macro/src/context.rs
+++ b/recallable-macro/src/context.rs
@@ -376,10 +376,10 @@ struct SimpleTypeCollector<'a> {
 
 impl<'ast> Visit<'ast> for SimpleTypeCollector<'ast> {
     fn visit_type_path(&mut self, node: &'ast syn::TypePath) {
-        if node.qself.is_none() {
-            if let Some(segment) = node.path.segments.first() {
-                self.used_simple_types.push(&segment.ident);
-            }
+        if node.qself.is_none()
+            && let Some(segment) = node.path.segments.first()
+        {
+            self.used_simple_types.push(&segment.ident);
         }
         syn::visit::visit_type_path(self, node);
     }

--- a/recallable-macro/src/lib.rs
+++ b/recallable-macro/src/lib.rs
@@ -46,10 +46,8 @@ pub fn recallable_model(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let crate_path = crate_path();
     let mut input = parse_macro_input!(item as ItemStruct);
 
-    if IS_SERDE_ENABLED {
-        if let Err(e) = check_no_serialize_derive(&input.attrs) {
-            return e.to_compile_error().into();
-        }
+    if IS_SERDE_ENABLED && let Err(e) = check_no_serialize_derive(&input.attrs) {
+        return e.to_compile_error().into();
     }
 
     let derives = if IS_SERDE_ENABLED {


### PR DESCRIPTION
Updates all references to the minimum supported Rust version across Cargo.toml, CI workflow, docs, and source code. Also refactors a nested if into a let-chain (enabled by edition 2024 / Rust 1.88).